### PR TITLE
pkgs: glp1: add cdrtools

### DIFF
--- a/pillars/pkgs/glp1/myreadiso.sls
+++ b/pillars/pkgs/glp1/myreadiso.sls
@@ -1,0 +1,2 @@
+pkgs:
+  - cdrtools

--- a/pillars/top.sls
+++ b/pillars/top.sls
@@ -13,6 +13,7 @@ base:
     - pkgs.dev-sdl
     - pkgs.archlinux
     - pkgs.vcsn
+    - pkgs.glp1.myreadiso
 
   'sup-archlinux-*':
     - main.sup-archlinux


### PR DESCRIPTION
This commit adds cdrtools because of the ING1 students currently needing mkisofs.
Beware, it's untested.