### PR TITLE
networkd: don't manage wireless interfaces

### DIFF
--- a/states/network/dhcp/networkd.sls
+++ b/states/network/dhcp/networkd.sls
@@ -3,12 +3,25 @@ network-dhcp-enable-networkd:
     - name: systemd-networkd
     - enable: True
 
-network-dhcp-configure-networkd:
+network-dhcp-configure-networkd-wifi:
   file.managed:
-    - name: /etc/systemd/network/dhcp.network
+    - name: /etc/systemd/network/20-wifi.network
+    - contents: |
+        [Match]
+        Driver=iwlwifi
+        [Link]
+        Unmanaged=yes
+        RequiredForOnline=no
+    - watch_in:
+      - service: network-dhcp-enable-networkd
+
+network-dhcp-configure-networkd-dhcp:
+  file.managed:
+    - name: /etc/systemd/network/30-dhcp.network
     - contents: |
         [Match]
         Name=*
+        Driver=!iwlwifi
         [Network]
         DHCP=ipv4
         {% if salt['pillar.get']('networkd-domains') %}


### PR DESCRIPTION
Managing wireless interfaces causes systemd-networkd-wait-online to hang waiting for device configuration.